### PR TITLE
Fixed a typo in an error message.

### DIFF
--- a/reciter.lua
+++ b/reciter.lua
@@ -32,7 +32,7 @@ if flag == 0 then
 end
 assert(words_prof_file)
 
-assert(config, "open errror")
+assert(config, "open error")
 local reciter_config = json.decode(config:read("a"))
 assert(reciter_config, "parse error")
 config:close()


### PR DESCRIPTION
In "reciter.lua" line 35 assert(config, "open errror"). There is a wrong character "r" in the string.
Should be "error" right?